### PR TITLE
Wtf ai installation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl -sSL https://raw.githubusercontent.com/davefowler/wtf-terminal-ai/main/inst
 ### Via pip
 
 ```bash
-pip install wtf-ai
+pip install git+https://github.com/davefowler/wtf-terminal-ai.git
 ```
 
 ### From source

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ This will:
 ### Option 2: pip
 
 ```bash
-pip install wtf-ai
+pip install git+https://github.com/davefowler/wtf-terminal-ai.git
 ```
 
 Simple. Direct. No frills. Just like we like our coffee.

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ Three ways to install, because choice is the illusion of control:
 === "pip"
 
     ```bash
-    pip install wtf-ai
+    pip install git+https://github.com/davefowler/wtf-terminal-ai.git
     ```
 
 === "From Source"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,7 +23,7 @@ Common issues and how to fix them.
 
 3. **Install in user mode:**
    ```bash
-   pip install --user wtf-ai
+   pip install --user git+https://github.com/davefowler/wtf-terminal-ai.git
    ```
 
 4. **Check PATH:**
@@ -57,7 +57,7 @@ Pick an alternative, or manually resolve:
 vim ~/.zshrc  # Remove old 'alias wtf=...'
 
 # Option 2: Install with different name
-pip install wtf-ai
+pip install git+https://github.com/davefowler/wtf-terminal-ai.git
 ln -s $(which wtf) ~/bin/wai
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -134,18 +134,20 @@ echo ""
 echo "Installing wtf-ai..."
 echo ""
 
-# Install wtf-ai
-if pip3 install --user wtf-ai 2>&1 | grep -q "Successfully installed"; then
+# Install wtf-ai from GitHub (not yet published to PyPI)
+GITHUB_URL="git+https://github.com/${REPO}.git"
+
+if pip3 install --user "$GITHUB_URL" 2>&1 | grep -q "Successfully installed"; then
     echo -e "${GREEN}✓${NC} wtf-ai installed successfully"
 else
     # Try without --user flag
-    if pip3 install wtf-ai 2>&1 | grep -q "Successfully installed"; then
+    if pip3 install "$GITHUB_URL" 2>&1 | grep -q "Successfully installed"; then
         echo -e "${GREEN}✓${NC} wtf-ai installed successfully"
     else
         echo -e "${RED}✗${NC} Installation failed"
         echo ""
         echo "You can try installing manually:"
-        echo "  pip3 install wtf-ai"
+        echo "  pip3 install git+https://github.com/${REPO}.git"
         exit 1
     fi
 fi


### PR DESCRIPTION
Update installation script and documentation to install `wtf-ai` directly from GitHub, as it is not yet published on PyPI.

The original installation method `pip install wtf-ai` failed because the package was not found on PyPI. This PR modifies `install.sh` and all relevant documentation files to use `pip install git+https://github.com/davefowler/wtf-terminal-ai.git` instead, allowing users to install the tool immediately. This change is temporary until the package is officially published to PyPI.

---
<a href="https://cursor.com/background-agent?bcId=bc-0afb0e9a-49bd-4237-9277-eabb3630cb1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0afb0e9a-49bd-4237-9277-eabb3630cb1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

