### PR TITLE
Update pip install to use GitHub repo URL (not on PyPI yet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curl -sSL https://raw.githubusercontent.com/davefowler/wtf-terminal-ai/main/inst
 ### Via pip
 
 ```bash
-pip install wtf-ai
+pip install git+https://github.com/davefowler/wtf-terminal-ai.git
 ```
 
 ### From source (for development)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ This will:
 ### Option 2: pip
 
 ```bash
-pip install wtf-ai
+pip install git+https://github.com/davefowler/wtf-terminal-ai.git
 ```
 
 Simple. Direct. No frills. Just like we like our coffee.

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ Three ways to install, because choice is the illusion of control:
 === "pip"
 
     ```bash
-    pip install wtf-ai
+    pip install git+https://github.com/davefowler/wtf-terminal-ai.git
     ```
 
 === "From Source"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,7 +57,7 @@ Pick an alternative, or manually resolve:
 vim ~/.zshrc  # Remove old 'alias wtf=...'
 
 # Option 2: Install with different name
-pip install wtf-ai
+pip install git+https://github.com/davefowler/wtf-terminal-ai.git
 ln -s $(which wtf) ~/bin/wai
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -236,7 +236,7 @@ INSTALL_METHOD=""
 
 if command -v pipx &> /dev/null; then
     # pipx is available - use it for clean isolation
-    if pipx install wtf-ai --force > /tmp/wtf-install.log 2>&1; then
+    if pipx install git+https://github.com/davefowler/wtf-terminal-ai.git --force > /tmp/wtf-install.log 2>&1; then
         INSTALL_SUCCESS=true
         INSTALL_METHOD="pipx"
     fi
@@ -244,7 +244,7 @@ fi
 
 if [ "$INSTALL_SUCCESS" = false ]; then
     # Try standard pip --user install
-    if $PIP_CMD install --user --upgrade wtf-ai > /tmp/wtf-install.log 2>&1; then
+    if $PIP_CMD install --user --upgrade git+https://github.com/davefowler/wtf-terminal-ai.git > /tmp/wtf-install.log 2>&1; then
         INSTALL_SUCCESS=true
         INSTALL_METHOD="pip"
     fi
@@ -254,7 +254,7 @@ if [ "$INSTALL_SUCCESS" = false ]; then
     # Check if we hit the PEP 668 externally-managed error
     if grep -q "externally-managed-environment" /tmp/wtf-install.log 2>/dev/null; then
         # Use --break-system-packages with --user (safe per PEP 668 recommendations)
-        if $PIP_CMD install --user --break-system-packages --upgrade wtf-ai > /tmp/wtf-install.log 2>&1; then
+        if $PIP_CMD install --user --break-system-packages --upgrade git+https://github.com/davefowler/wtf-terminal-ai.git > /tmp/wtf-install.log 2>&1; then
             INSTALL_SUCCESS=true
             INSTALL_METHOD="pip"
         fi
@@ -263,7 +263,7 @@ fi
 
 if [ "$INSTALL_SUCCESS" = false ]; then
     # Try without --user (for virtual environments)
-    if $PIP_CMD install --upgrade wtf-ai > /tmp/wtf-install.log 2>&1; then
+    if $PIP_CMD install --upgrade git+https://github.com/davefowler/wtf-terminal-ai.git > /tmp/wtf-install.log 2>&1; then
         INSTALL_SUCCESS=true
         INSTALL_METHOD="pip"
     fi
@@ -278,10 +278,10 @@ else
     cat /tmp/wtf-install.log
     echo ""
     echo "You can try installing manually:"
-    echo -e "  ${CYAN}$PIP_CMD install --user wtf-ai${NC}"
+    echo -e "  ${CYAN}$PIP_CMD install --user git+https://github.com/davefowler/wtf-terminal-ai.git${NC}"
     echo ""
     echo "Or use pipx (recommended for CLI tools):"
-    echo -e "  ${CYAN}brew install pipx && pipx install wtf-ai${NC}"
+    echo -e "  ${CYAN}brew install pipx && pipx install git+https://github.com/davefowler/wtf-terminal-ai.git${NC}"
     exit 1
 fi
 


### PR DESCRIPTION
Since wtf-ai is not yet published to PyPI, update all installation instructions to use the GitHub repository URL directly:
  pip install git+https://github.com/davefowler/wtf-terminal-ai.git

Closes #2

https://claude.ai/code/session_01L12fyjrMzU1WNdScRVdNLz